### PR TITLE
Fixes for radosgw and haproxy stats

### DIFF
--- a/deployment_scripts/controller-firewall.pp
+++ b/deployment_scripts/controller-firewall.pp
@@ -1,0 +1,12 @@
+notice('MODULAR: standalone-ceph/controller-firewall.pp')
+
+$network_scheme     = hiera_hash('network_scheme', {})
+$management_nets    = get_routable_networks_for_network_role($network_scheme, 'mgmt/vip')
+$haproxy_stats_port = 10000
+
+openstack::firewall::multi_net {'300 haproxy stats tcp':
+  port        => $haproxy_stats_port,
+  proto       => 'tcp',
+  action      => 'accept',
+  source_nets => $management_nets,
+}

--- a/deployment_scripts/radosgw.pp
+++ b/deployment_scripts/radosgw.pp
@@ -55,6 +55,7 @@ if $use_ceph and $storage_hash['objects_ceph'] {
   if ($::osfamily == 'Debian'){
     apache::mod {'rewrite': }
     apache::mod {'fastcgi': }
+    apache::mod {'proxy': }
   }
   include ::tweaks::apache_wrappers
   include ceph::params

--- a/deployment_tasks.yaml
+++ b/deployment_tasks.yaml
@@ -48,6 +48,16 @@
 - id: enable_rados
   type: skipped
 
+- id: controller-firewall
+  type: puppet
+  groups: [primary-controller, controller]
+  required_for: [firewall]
+  requires: [netconfig]
+  parameters:
+    puppet_manifest: controller-firewall.pp
+    puppet_modules: modules:/etc/puppet/modules
+    timeout: 3600
+
 # Override hiera for at least primary_mon value
 - id: hiera-override-for-standalone-ceph
   type: puppet


### PR DESCRIPTION
- radosgw manifest should enable mod_proxy
  before attempting to start apache
- Open port 10000 on controllers so that
  haproxy_backend_status resources can operate
  from ceph-mon role

Change-Id: I09c2ad1c6d00702f855dd04d0b9be82fc887b7b8
